### PR TITLE
Fix avahi-aliases task when running playbook

### DIFF
--- a/.nebula/ansible/roles/nebula/tasks/avahi.yml
+++ b/.nebula/ansible/roles/nebula/tasks/avahi.yml
@@ -1,6 +1,6 @@
 ---
 - name: install packages required for avahi-aliases
-  package: name={{item}} state=latest update_cache=yes
+  apt: name={{item}} state=latest update_cache=yes
   with_items:
     - avahi-daemon
     - python-avahi


### PR DESCRIPTION
Change `package` to be `apt` in avahi-aliases task to resolve error referenced in issue #6:

```
    default: Running ansible-playbook...
ERROR: package is not a legal parameter in an Ansible task or handler
Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

This was the only way I could run `vagrant up` successfully and spin up a Drupal project.

Source: http://docs.ansible.com/ansible/apt_module.html#examples
